### PR TITLE
load feature.pm so feature->import is not ignored

### DIFF
--- a/t/lib/Test/DBIx/EAV.pm
+++ b/t/lib/Test/DBIx/EAV.pm
@@ -10,6 +10,7 @@ use Data::Dumper;
 use lib 'lib';
 use DBIx::EAV;
 use YAML;
+use feature ();
 
 our @EXPORT = (
     @Test2::Bundle::Extended::EXPORT,


### PR DESCRIPTION
Perl will ignore calls to ->import if the method does not exist. feature::import doesn't exist without loading feature.pm, so the attempt to enable 5.10 features was being ignored.

Future versions of perl are intending to make calls to import with unhandled arguments like this an error.